### PR TITLE
Fix default caddyfile for targets using SSL

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -96,6 +96,7 @@ $HOSTNAME {
   tls $EMAIL
   proxy / 127.0.0.1:$ALICE_PORT {
     transparent
+    header_upstream X-Forwarded-Ssl on
   }
 }
 EOM"


### PR DESCRIPTION
This fixes all instances where the upstream website uses https.
/cc @nicoladiaz 