### PR TITLE
CircleCI gh-pages deployment

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,16 @@
+# Setup
+
+[Complete guide](https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/)
+
+- Generate a SSH key pair: `ssh-keygen -C travisci-alice-deploy -m PEM -N "" -f travisci_id_rsa`
+- Go to https://circleci.com/gh/NInfolab/alice/edit#ssh
+    + Add a new key
+        * Host: github.com
+        * Key: paste content of the __private__ key file
+- Copy the fingerprint into .circleci/config.yaml
+    + 
+    ```yaml
+    - add_ssh_keys:
+        fingerprints: [ "bd:07:5f:84:3b:0c:41:3d:7b:04:50:17:27:bf:7d:a0" ]
+    ```
+- Add the public key to https://github.com/NInfolab/alice/settings/keys with write access

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - gh-pages-deploy:
+          # Run this job only on master
+          filters:
+            branches:
+              only: master
+
+jobs:
+  gh-pages-deploy:
+    # Docker image to use for this job
+    docker:
+      - image: starefossen/ruby-node:latest
+    steps:
+      - checkout
+      - restore_cache:
+          keys: [ bundle-deps ]
+      - run:
+          name: Install dependencies
+          command: |
+            git config user.name "CircleCI"
+            git config user.email "circleci@-"
+
+            cd docs
+            bundle install --path vendor/bundle
+      - save_cache:
+          key: bundle-deps
+          paths:
+            - docs/vendor/bundle/
+      - add_ssh_keys:
+          fingerprints: [ "bd:07:5f:84:3b:0c:41:3d:7b:04:50:17:27:bf:7d:a0" ]
+      - run:
+          name: Build and deploy
+          command: |
+            cd docs
+            ./deploy.sh
+
+
+


### PR DESCRIPTION
You'll need to add the following deploy key into the repository settings
`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDLehOTB5yHjVCbQYjh2X9XNHA+56mRW8rzyFfPg2JHPIsCGcQLQyIe5ZjVcVVq+Z9dG1X2GYqtEDV6I19divkRdHUivQXCcO4CSol81NSzaBHhAIA3s5poJl3sEEkVKnWXJ+CKNa7m4d/CpQi1g+wv0VOxOexIziTczSFt6BuGuMDqvLrkmM1eZZyhduxbPtbWquVSoQdghRRpl2+ot1AHRExG0BiwBBKyJvv2jPpU6Xq13ZPXjIXsQycS7vwslqT4k9SSAjU9/cuHsDbNUTs6vocz1H4Td1LtakaGGrWej+g9/FF0PSlzk2t3dE9KrbMPs+rz8WOg1O7Bd+O84TD circleci-alice-deploy`

I already added the private key file into the CircleCI repository settings

